### PR TITLE
Fix interface_driver option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,9 +23,11 @@ Install
   [DEFAULT]
   verbose = True
   debug = True
+  rabbit_user = neutron
   rabbit_password = password
   rabbit_hosts = localhost
   rpc_backend = neutron.openstack.common.rpc.impl_kombu
+  interface_driver = neutron.agent.linux.interface.OVSInterfaceDriver
 
   [database]
   sql_connection = mysql://root:password@localhost/ovs_neutron?charset=utf8

--- a/bin/l3_healthcheck
+++ b/bin/l3_healthcheck
@@ -329,6 +329,7 @@ if __name__ == "__main__":
     cfg.CONF.register_opts(interface.OPTS)
     cfg.CONF.register_opts(external_process.OPTS)
     config.register_root_helper(cfg.CONF)
+    config.register_interface_driver_opts_helper(cfg.CONF)
 
     logging.setup(product_name)
     main()

--- a/etc/l3_healthcheck.ini
+++ b/etc/l3_healthcheck.ini
@@ -1,9 +1,11 @@
 [DEFAULT]
 verbose = True
 debug = True
+rabbit_user = neutron
 rabbit_password = password
 rabbit_hosts = localhost
 rpc_backend = neutron.openstack.common.rpc.impl_kombu
+interface_driver = neutron.agent.linux.interface.OVSInterfaceDriver
 
 [L3HEALTHCHECK]
 check_interval = 1


### PR DESCRIPTION
Option interface_driver was not loaded from the configuration,
which caused the following error:

"An interface driver must be specified"
